### PR TITLE
Parse pixel ratio as integer and add basic validation

### DIFF
--- a/dist/server.js
+++ b/dist/server.js
@@ -44,16 +44,16 @@ var renderImage = function renderImage(params, response, next, tilePath) {
     var width = params.width,
         height = params.height,
         _params$token = params.token,
-        token = _params$token === undefined ? null : _params$token,
-        _params$ratio = params.ratio,
-        ratio = _params$ratio === undefined ? 1 : _params$ratio;
+        token = _params$token === undefined ? null : _params$token;
     var style = params.style,
         _params$zoom = params.zoom,
         zoom = _params$zoom === undefined ? null : _params$zoom,
         _params$center = params.center,
         center = _params$center === undefined ? null : _params$center,
         _params$bounds = params.bounds,
-        bounds = _params$bounds === undefined ? null : _params$bounds;
+        bounds = _params$bounds === undefined ? null : _params$bounds,
+        _params$ratio = params.ratio,
+        ratio = _params$ratio === undefined ? 1 : _params$ratio;
 
 
     if (typeof style === 'string') {
@@ -86,6 +86,12 @@ var renderImage = function renderImage(params, response, next, tilePath) {
         zoom = parseFloat(zoom);
         if (zoom < 0 || zoom > 22) {
             return next(new _restifyErrors2.default.BadRequestError('Zoom level is outside supported range (0-22): ' + zoom));
+        }
+    }
+    if (ratio !== null) {
+        ratio = parseInt(ratio);
+        if (!ratio || ratio < 1) {
+            return next(new _restifyErrors2.default.BadRequestError('Ratio is outside supported range (>=1): ' + ratio));
         }
     }
     if (bounds !== null) {

--- a/src/server.js
+++ b/src/server.js
@@ -20,10 +20,10 @@ const PARAMS = {
 
 const renderImage = (params, response, next, tilePath) => {
     const {
-        width, height, token = null, ratio = 1
+        width, height, token = null
     } = params
     let {
-        style, zoom = null, center = null, bounds = null
+        style, zoom = null, center = null, bounds = null, ratio = 1
     } = params
 
     if (typeof style === 'string') {
@@ -68,6 +68,12 @@ const renderImage = (params, response, next, tilePath) => {
         zoom = parseFloat(zoom)
         if (zoom < 0 || zoom > 22) {
             return next(new restifyErrors.BadRequestError(`Zoom level is outside supported range (0-22): ${zoom}`))
+        }
+    }
+    if (ratio !== null) {
+        ratio = parseInt(ratio)
+        if (!ratio || ratio < 1) {
+            return next(new restifyErrors.BadRequestError(`Ratio is outside supported range (>=1): ${ratio}`))
         }
     }
     if (bounds !== null) {


### PR DESCRIPTION
The ratio variable in the mbgl-server component was not parsed as integer which caused the following error (when the HTTP parameter ratio was specified):

<pre>
Error processing render request Error: Options object 'ratio' property must be a number
    at new Map (/home/username/mbgl-renderer/node_modules/@mapbox/mapbox-gl-native/platform/node/index.js:19:12)
    at /home/username/mbgl-renderer/dist/render.js:483:19
    at new Promise (<anonymous>)
    at render (/home/username/mbgl-renderer/dist/render.js:332:12)
    at renderImage (/home/username/mbgl-renderer/dist/server.js:112:30)
    at Server.<anonymous> (/home/username/mbgl-renderer/dist/server.js:170:12)
    at next (/home/username/mbgl-renderer/node_modules/restify/lib/server.js:1126:29)
    at f (/home/username/mbgl-renderer/node_modules/once/once.js:36:25)
    at Server.<anonymous> (/home/username/mbgl-renderer/node_modules/node-restify-validation/lib/index.js:64:9)
    at next (/home/username/mbgl-renderer/node_modules/restify/lib/server.js:1126:29)
</pre>