### PR TITLE
Add option to add overlay files to map

### DIFF
--- a/dist/render.js
+++ b/dist/render.js
@@ -355,7 +355,9 @@ var render = function render(style) {
         _options$zoom = options.zoom,
         zoom = _options$zoom === void 0 ? null : _options$zoom,
         _options$tilePath = options.tilePath,
-        tilePath = _options$tilePath === void 0 ? null : _options$tilePath;
+        tilePath = _options$tilePath === void 0 ? null : _options$tilePath,
+        _options$fit = options.fit,
+        fit = _options$fit === void 0 ? false : _options$fit;
 
     if (!style) {
       throw new Error('style is a required parameter');
@@ -405,6 +407,11 @@ var render = function render(style) {
       /* eslint-disable prefer-destructuring */
 
       center = viewport.center;
+
+      if (fit) {
+        // Hack to add padding around bounding box fitted to overlay
+        zoom -= 0.05;
+      }
     } // validate that all local mbtiles referenced in style are
     // present in tilePath and that tilePath is not null
 

--- a/package.json
+++ b/package.json
@@ -20,12 +20,15 @@
         "@mapbox/geo-viewport": "^0.4.0",
         "@mapbox/mapbox-gl-native": "^5.0.0",
         "@mapbox/mbtiles": "^0.11.0",
+        "@mapbox/togeojson": "^0.16.0",
+        "@turf/bbox": "^6.0.1",
         "commander": "^3.0.2",
         "node-restify-validation": "^1.3.0",
         "request": "^2.87.0",
         "restify": "^8.4.0",
         "restify-errors": "^8.0.1",
-        "sharp": "^0.23.1"
+        "sharp": "^0.23.1",
+        "xmldom": "^0.1.27"
     },
     "devDependencies": {
         "@babel/cli": "^7.6.4",

--- a/src/render.js
+++ b/src/render.js
@@ -269,7 +269,7 @@ const getRemoteAsset = (url, callback) => {
  */
 export const render = (style, width = 1024, height = 1024, options) => new Promise((resolve, reject) => {
     const { bounds = null, bearing = 0, pitch = 0, token = null, ratio = 1 } = options
-    let { center = null, zoom = null, tilePath = null } = options
+    let { center = null, zoom = null, tilePath = null, fit = false } = options
 
     if (!style) {
         throw new Error('style is a required parameter')
@@ -316,6 +316,12 @@ export const render = (style, width = 1024, height = 1024, options) => new Promi
         zoom = Math.max(viewport.zoom - 1, 0)
         /* eslint-disable prefer-destructuring */
         center = viewport.center
+
+        if (fit) {
+            // Hack to add padding around bounding box fitted to overlay
+            zoom -=0.05
+        }
+
     }
 
     // validate that all local mbtiles referenced in style are


### PR DESCRIPTION
When starting a server you set folder from which GPX/Geojson files are
loaded. Then you can specify which file to load on each request. Files
are separated with ",". It is also possible to fit bounds on loaded
files.

I'm using this renderer to render map in video. That is why I specify folder at starting of the server and then only filenames. 

Javascript is not my strong point so code is not nice.