### PR TITLE
Fix Docker healthcheck

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get update && \
   libprotobuf-dev \
   libxxf86vm-dev \
   xvfb \
+  curl \
   x11-utils && \
   rm -rf /var/lib/apt/lists/* && \
   # install node deps, then remove any that are not used in production


### PR DESCRIPTION
I noticed that the healthcheck is always failing, because `curl` is missing in the image.